### PR TITLE
user_default_profile: env variable to allow user to specify default profile/credentials

### DIFF
--- a/ebzl/lib/config.py
+++ b/ebzl/lib/config.py
@@ -11,7 +11,7 @@ AWS_CLI_CREDENTIALS_PATH = "~/.aws/credentials"
 
 AWS_CLI_CONFIG_PATH = "~/.aws/config"
 
-DEFAULT_PROFILE_NAME = "default"
+DEFAULT_PROFILE_NAME = os.getenv("AWS_DEFAULT_PROFILE", "default")
 
 
 class NoConfigFoundException(Exception):


### PR DESCRIPTION
Specify a default profile via env `AWS_DEFAULT_PROFILE` [ref](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html) so I don't have to have duplicates in my credentials|config files 
