### PR TITLE
user_default_profile: env variable to allow user to specify default profile/credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+## 2015-08-19
+- `AWS_DEFAULT_PROFILE` ENV  variable to allow user to specify default profile/credentials
+
 ## 2015-08-17
 - Bump boto3 version to 1.1.1
 - `ebzl instances -n` display Name tag value (and sorts the output by it)

--- a/ebzl/lib/config.py
+++ b/ebzl/lib/config.py
@@ -11,7 +11,7 @@ AWS_CLI_CREDENTIALS_PATH = "~/.aws/credentials"
 
 AWS_CLI_CONFIG_PATH = "~/.aws/config"
 
-DEFAULT_PROFILE_NAME = "default"
+DEFAULT_PROFILE_NAME = os.getenv("AWS_DEFAULT_PROFILE", "default")
 
 
 class NoConfigFoundException(Exception):


### PR DESCRIPTION
Specify a default profile via env `AWS_DEFAULT_PROFILE`\* so I don't have to have duplicates in my credentials|config files
- [ref](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html)
